### PR TITLE
added options to save/load/list settings as profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ Interacts with experimental Acer-wmi kernel module.
     0   -> Minimum blue range
     255 -> Maximum blue range
 
+-save [profile name]
+    Add as last argument to save to a profile
+
+-load [profile name]
+    Loads the profile if it exists
+
+-list
+    Lists all the saved profiles in config directory
+    config directory is "$HOME/.config/predator/saved profiles/"
+
 optional arguments:
   -h, --help     show this help message and exit
   -m MODE
@@ -158,6 +168,9 @@ optional arguments:
   -cR RED
   -cG GREEN
   -cB BLUE
+  -save NAME
+  -load NAME
+  -list
 ```
 Sample usages:
 
@@ -182,8 +195,11 @@ Static waving (speed=0):
 Static mode coloring (zone=1 => most left zone, color=blue):  
 `./facer_rgb.py -m 0 -z 1 -cR 0 -cB 255 -cG 0`
 
-Static mode coloring (zone=4 => most right zone, color=purple):  
+Static mode coloring (zone=4 => most right zone, color=purple) and save it as example:  
 `./facer_rgb.py -m 0 -z 4 -cR 255 -cB 255 -cG 0`
+
+Load the previously saved profile:
+`./facer_rgb.py -load example`
 
 
 ## Known problems

--- a/facer_rgb.py
+++ b/facer_rgb.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 import argparse
+import json
+from pathlib import Path
 
 PAYLOAD_SIZE = 16
 CHARACTER_DEVICE = "/dev/acer-gkbbl-0"
@@ -7,7 +9,11 @@ CHARACTER_DEVICE = "/dev/acer-gkbbl-0"
 PAYLOAD_SIZE_STATIC_MODE = 4
 CHARACTER_DEVICE_STATIC = "/dev/acer-gkbbl-static-0"
 
-parser = argparse.ArgumentParser(description="""Interacts with experimental Acer-wmi kernel module.
+CONFIG_DIRECTORY = str(Path.home()) + "/.config/predator/saved profiles"
+path = Path(CONFIG_DIRECTORY)
+path.mkdir(parents=True, exist_ok=True)
+
+parser = argparse.ArgumentParser(description=f"""Interacts with experimental Acer-wmi kernel module.
 -m [mode index]
     Effect modes:
     0 -> Static [Accepts ZoneID[1,2,3,4] + RGB Color]
@@ -61,25 +67,38 @@ parser = argparse.ArgumentParser(description="""Interacts with experimental Acer
     0   -> Minimum blue range
     255 -> Maximum blue range
 
+-save [profile name]
+    Add as last argument to save to a profile
+
+-load [profile name]
+    Loads the profile if it exists
+
+-list
+    Lists all the saved profiles in config directory
+    config directory is '{CONFIG_DIRECTORY}'
+
 Some sample commands:
 
 Breath effect with Purple color(speed=4, brightness=100):
-python3 facer_rgb.py -m 1 -s 4 -b 100 -cR 255 -cG 0 -cB 255
+./facer_rgb.py -m 1 -s 4 -b 100 -cR 255 -cG 0 -cB 255
 
 Neon effect(speed=3, brightness=100):
-python3 facer_rgb.py -m 2 -s 3 -b 100
+./facer_rgb.py -m 2 -s 3 -b 100
 
 Wave effect(speed=5, brightness=100):
-python3 facer_rgb.py -m 3 -s 5 -b 100
+./facer_rgb.py -m 3 -s 5 -b 100
 
 Shifting effect with Blue color (speed=5, brightness=100):
-python3 facer_rgb.py -m 4 -s 5 -b 100 -cR 0 -cB 255 -cG 0
+./facer_rgb.py -m 4 -s 5 -b 100 -cR 0 -cB 255 -cG 0
 
 Zoom effect with Green color (speed=7, brightness=100):
-python3 facer_rgb.py -m 5 -s 7 -b 100 -cR 0 -cB 0 -cG 255
+./facer_rgb.py -m 5 -s 7 -b 100 -cR 0 -cB 0 -cG 255 -save zoom
 
-Static waving (speed=0):
-python3 facer_rgb.py -m 3 -s 0 -b 100
+Static waving (speed=0) and save it as example:
+./facer_rgb.py -m 3 -s 0 -b 100 -save example
+
+Load the previously saved profile:
+./facer_rgb.py -load example
 """, formatter_class=argparse.RawTextHelpFormatter)
 
 parser.add_argument('-m',
@@ -122,7 +141,31 @@ parser.add_argument('-cB',
                     dest='blue',
                     default=50)
 
+parser.add_argument('-save')
+
+parser.add_argument('-load')
+
+parser.add_argument('-list',
+                    action='store_true')
+
 args = parser.parse_args()
+
+if args.list:
+    print("Saved profiles:")
+    for filepath in list(path.glob('*.*')): print(f"\t{filepath.stem}")
+    exit()
+
+if args.load:
+    with open(f"{CONFIG_DIRECTORY}/{args.load}.json", 'rt') as f:
+        t_args = argparse.Namespace()
+        t_args.__dict__.update(json.load(f))
+        args = parser.parse_args(namespace=t_args)
+
+if args.save:
+    with open(f"{CONFIG_DIRECTORY}/{args.save}.json", 'wt') as f:
+        vars(args).pop('save')
+        vars(args).pop('load')
+        json.dump(vars(args), f, indent=4)
 
 if args.mode == 0:
     # Static coloring mode


### PR DESCRIPTION
### Added three new arguments to save/load/list settings as profiles

- -save [profile name]
    Add as last argument to save to a profile

- -load [profile name]
    Loads the profile if it exists

- -list
    Lists all the saved profiles in config directory
    config directory is "$HOME/.config/predator/saved profiles/"