### PR TITLE
Call GetGamingSysInfo WMI method to enable Nitro5 keyboard LEDs

### DIFF
--- a/src/facer.c
+++ b/src/facer.c
@@ -68,6 +68,7 @@ MODULE_LICENSE("GPL");
 
 #define ACER_WMID_SET_GAMING_LED_METHODID 2
 #define ACER_WMID_GET_GAMING_LED_METHODID 4
+#define ACER_WMID_GET_GAMING_SYSINFO_METHODID 5
 #define ACER_WMID_SET_GAMING_STATIC_LED_METHODID 6
 #define ACER_WMID_SET_GAMING_FAN_BEHAVIOR 14
 #define ACER_WMID_SET_GAMING_MISC_SETTING_METHODID 22
@@ -2951,6 +2952,7 @@ static void __init create_debugfs(void)
 static int __init acer_wmi_init(void)
 {
 	int err;
+	u64 gaming_sysinfo;
 
 	pr_info("Acer Laptop ACPI-WMI Extras\n");
 
@@ -3027,6 +3029,12 @@ static int __init acer_wmi_init(void)
 	}
 
 	set_quirks();
+
+	/*
+	 * Querying GetGamingSysInfo appears to be required to enable Nitro AN515-57
+	 * and possibly other Acer (Predator/Nitro) 4 zone LED keyboards.
+	 */
+	WMI_gaming_execute_u64(ACER_WMID_GET_GAMING_SYSINFO_METHODID, 0, &gaming_sysinfo);
 
 	if (dmi_check_system(video_vendor_dmi_table))
 		acpi_video_set_dmi_backlight_type(acpi_backlight_vendor);

--- a/src/facer.c
+++ b/src/facer.c
@@ -3035,6 +3035,8 @@ static int __init acer_wmi_init(void)
 	 * and possibly other Acer (Predator/Nitro) 4 zone LED keyboards.
 	 */
 	WMI_gaming_execute_u64(ACER_WMID_GET_GAMING_SYSINFO_METHODID, 0, &gaming_sysinfo);
+	/* Turn on all 4 zones */
+	WMI_gaming_execute_u64(ACER_WMID_SET_GAMING_LED_METHODID, 8L | (15UL<<40), NULL);
 
 	if (dmi_check_system(video_vendor_dmi_table))
 		acpi_video_set_dmi_backlight_type(acpi_backlight_vendor);


### PR DESCRIPTION
closes #21 

This now works for me on Ubuntu 22.04.1 on my Acer Nitro AN515-57 laptop, using the install.sh script (I haven't tested the install_service.sh method yet but it should work the same).

I am hoping that this might fix other Nitro models and maybe even some Predator ones -- and any model that 'works' after starting Windows first. 

I'm happy to make changes to this PR to put the query in a better place. I couldn't decide if it fit into 'quirks' or not. The WMI call is a GET method, and I'm not even using the returned result for anything. 

Initially I added this as a debugging line to see if the Acer Gaming Profile Setting or Acer Gaming System Information was different between booting into Windows first, and booting straight into Ubuntu, but getting the Gaming System Info was sufficient to make it work.

I had used the Windows WMI event logging and saw the initial sufficient WMI calls were:

GetGamingSysInfo
SetGamingLED

and maybe one other call (my notes are on the Windows system). I wasn't expecting the Get method to be the one that changed something in the device though.  Using a Get to modify something is strange, but that looks like what's happening.

I'd be very interested to know if this gets any other models working, if there is anyone else out there who wants to test this.

@JafarAkhondali you might have a better idea of where to put this call. I'm happy to make changes and follow any advice you have. Thanks for creating this module!

@Aeres-u99 -- thanks for your comments on #21 , I'm not sure if you have a Nitro 5 now to test this on, but this works for me.

**EDIT:**
Here are some test cases I ran using this branch running as a service:
|#| CASE                         | Off state | Init | GRUB Bootmenu | Login welcome | Login mid | Login wait | Logged in |
|-|------                        |-----------|------|-----------|---------------|-----------|------------|-----------|
| A.1 | static: Windows (R-G-B-Y) -> Windows | Off       | Red sweep: 1-2-3-4 | Red | Red | R-G-B-Y | R-G-B-Y | R-G-B-Y |
| [My Acer Nitro branch](https://github.com/JafarAkhondali/acer-predator-turbo-and-rgb-keyboard-linux-module/pull/69/commits/6aabf6ba582e55e03aba4c736cab93e2034df469):     |
| B.1 | static: Windows (R-G-B-Y) -> Linux | Off | Red sweep: 1-2-3-4 | Red | R-G-B-Y | R-G-B-Y | R-G-B-Y | R-G-B-Y |
| B.2 | dynamic: W (Green Shift LTR) -> L | Off | Red sweep: 1-2-3-4 | Red | Green Shift | Green Shift | Green Shift | Green Shift |
| B.3 | static: L (Y-B-G-R) -> W | Off | Red sweep: 1-2-3-4 | Red | Red | Y-B-G-R (from keyb last saved state, under Linux) | R-G-B-R (loaded from Windows registry config) | R-G-B-R |
| B.4 | dynamic: L (Blue shift RTL) -> W | Off | Red sweep: 1-2-3-4 | Red | Red | Blue shift RTL from keyb last saved state, under Linux) | Green shift LTR (loaded from last saved Windows registry config) | Green shift LTR |

For me, with this branch, facer.py works to change the LEDs everytime I boot into Linux now. I have it installed as a service.

Points to note:
* The pre-bootmenu sweep and the constant Red state on every initial boot seem to be coming from the keyboard. If this isn't happening for anyone with a similar laptop, there's likely some device initialization code that the Windows software does. Some Windows registry keys and decompiled (using DotPeek) source suggests there is some 'first run' detection going on, but I haven't dug into that yet. (I didn't need to to fix my immediate problem).
* The device stores an internal config -- the Windows boot will load whatever I set under Linux briefly before overwriting it with the Nitro / Predator service last saved config by software.
* facer.py never overwrites the keyboard saved config automatically because that's not an implemented feature yet. The code I added appears to me to be sufficient to load the internal config to replace the default boot constant red.
* I can't see any behaviour difference between dynamic and static modes, in any combination. For testing purposes, they seem the same.

I'm happy to keep working on this if anyone wants me to dig further into uncovering whether the Windows Nitro app is performing any one time device intitialization, which might be a factor. I'll probably need some info about your device state though. The red-sweep on initial boot and constant red illumination looks like confirmation that the keyboard device is 'initialised' and my branch will work with it. I can't remember ever not seeing this on my laptop though.

I accept that calling a GET method to make this work seems strange, but that's what I'm seeing. I used DotPeek to view the Nitrosense app, and couldn't see any other obvious calls early in the process, which threw me off for a while. I was using the WMI event monitor, but trying to link it back to what I could see within the DotPeek decompilation.

I feel like I've fixed my keyboard problems, but I think it'd be nice to have this work without requiring a Windows boot to initialize the keyboard (at this stage I don't even know this _is_ required -- I'm just suspecting it might be the case if it's not working for other AN515-57s).

It looks like this has helped getting a PH315-55 working, which is great!  https://github.com/JafarAkhondali/acer-predator-turbo-and-rgb-keyboard-linux-module/issues/53#issuecomment-1304608901 --

@JafarAkhondali  I'm happy to help  make more sense of all the different Nitro and Predator model complexity, since I've already invested some time here :) 