### PR TITLE
removing acpi_video_set_dmi_backlight_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,17 +75,17 @@ Arch (I don't use arch anymore btw):
 ```bash
 git clone https://github.com/JafarAkhondali/acer-predator-turbo-and-rgb-keyboard-linux-module
 cd "acer-predator-turbo-and-rgb-keyboard-linux-module"
-chmod +x ./install.sh
+chmod +x ./*.sh
 sudo ./install.sh
 ```
 
-### Install as a systemd service (Will work after reboot) For Arch Linux from [ExodiaOS Repo](https://github.com/Exodia-OS/exodia-repo/blob/master/x86_64/Predator-Sense-systemd-git-1.0-2-any.pkg.tar.zst)
+### Install as a systemd service (Will work after reboot) for Arch Linux from [ExodiaOS Repo](https://github.com/Exodia-OS/exodia-repo/blob/master/x86_64/)
 
 ```bash
 
-wget https://raw.githubusercontent.com/Exodia-OS/exodia-repo/master/x86_64/Predator-Sense-systemd-git-1.0-2-any.pkg.tar.zst
+# Download the latest version of Predator-Sense-CLI available)
 
-sudo pacman -U Predator-Sense-systemd-git-1.0-2-any.pkg.tar.zst
+sudo pacman -U Predator-Sense-CLI-{version}-any.pkg.tar.zst
 
 ```
 

--- a/src/facer.c
+++ b/src/facer.c
@@ -11,6 +11,7 @@
 
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 
+#include <acpi/video.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/init.h>
@@ -29,8 +30,6 @@
 #include <linux/input.h>
 #include <linux/cdev.h>
 #include <linux/input/sparse-keymap.h>
-#include <acpi/video.h>
-
 
 MODULE_AUTHOR("Carlos Corbacho");
 MODULE_DESCRIPTION("Acer Laptop WMI Extras Driver");
@@ -3041,9 +3040,6 @@ static int __init acer_wmi_init(void)
 	}
 
 	set_quirks();
-
-	if (dmi_check_system(video_vendor_dmi_table))
-		acpi_video_set_dmi_backlight_type(acpi_backlight_vendor);
 
 	if (acpi_video_get_backlight_type() != acpi_backlight_vendor)
 		interface->capability &= ~ACER_CAP_BRIGHTNESS;


### PR DESCRIPTION
Currently, whenever i tried to install this project, whether single use or as a service, it always returns this message which shows on kernel 6.1.1-arch1-1
![image](https://user-images.githubusercontent.com/71018479/209247480-95555177-c2a1-48f3-ada9-8f4d29bb762d.png)

this is my device
```
System Information
	Manufacturer: Acer
	Product Name: Nitro AN515-57
	Version: V1.19
	Serial Number: NHQEUSN0031520747D3400
	UUID: 682e0646-4a65-ec11-80e2-088fc3381eb0
	Wake-up Type: Power Switch
--
Base Board Information
	Manufacturer: TGL
	Product Name: Scala_TLS
	Version: V1.19
	Serial Number: NBQUE1100115253A343400
	Asset Tag: Type2 - Board Asset Tag
	Features:
```

after some research, I have found that acpi_video_set_dmi_backlight_type has been removed and should not be used in production.

```
acpi_video_set_dmi_backlight_type() is troublesome because it may end
up getting called after other backlight drivers have already called
acpi_video_get_backlight_type() resulting in the other drivers
already being registered even though they should not.

In case of the acpi_video backlight, acpi_video_set_dmi_backlight_type()
actually calls acpi_video_unregister_backlight() since that is often
probed earlier, leading to userspace seeing the acpi_video0 class
device being briefly available, leading to races in userspace where
udev probe-rules try to access the device and it is already gone.

All callers have been fixed to no longer call it, so remove
acpi_video_set_dmi_backlight_type() now.
```
this is a note from https://lore.kernel.org/all/20220818184302.10051-28-hdegoede@redhat.com which explains why this call should not be used anymore

A simple removal of said line of code is enough to fix the issue. here's a screenshot after the fix have been made
![image](https://user-images.githubusercontent.com/71018479/209248725-90eac940-f878-4c1a-ae8c-04b48fa3952f.png)

It should be noted that i have only tested it on my personal device on this specific kernel version. so further testing before merge maybe needed