### PR TITLE
Fixing incompatible-pointer-types

### DIFF
--- a/src/facer.c
+++ b/src/facer.c
@@ -1996,7 +1996,7 @@ struct gkbbl_device_data {
 static struct class *gkbbl_dev_class;
 static struct gkbbl_device_data gkbbl_dev_data;
 
-static int gkbbl_dev_uevent(struct device *dev, struct kobj_uevent_env *env)
+static int gkbbl_dev_uevent(const struct device *dev, struct kobj_uevent_env *env)
 {
 	add_uevent_var(env, "DEVMODE=%#o", 0666);
 	return 0;
@@ -2100,7 +2100,7 @@ struct gkbbl_static_device_data {
 static struct class *gkbbl_static_dev_class;
 static struct gkbbl_device_data gkbbl_static_dev_data;
 
-static int gkbbl_static_dev_uevent(struct device *dev, struct kobj_uevent_env *env)
+static int gkbbl_static_dev_uevent(const struct device *dev, struct kobj_uevent_env *env)
 {
 	add_uevent_var(env, "DEVMODE=%#o", 0666);
 	return 0;


### PR DESCRIPTION
![Screenshot from 2023-02-28 17-36-27](https://user-images.githubusercontent.com/71018479/221846650-c9989d2d-e392-48d3-b4bf-81393bd01c7a.png)

This commit fixes an issue that I have noticed on ArchLinux with kernel 6.2.x (Vanilla and Zen), which there is a compilation error incompatible-pointer-types on line 2019 and 2123. 

Adding `const` qualifier to `gkbbl_dev_uevent` and `gkbbl_static_dev_uevent` is sufficient to fix this issue