### PR TITLE
Allow fan control via character device (e.g. "echo 1 > /dev/acer-max-fan-0")

### DIFF
--- a/src/facer.c
+++ b/src/facer.c
@@ -387,10 +387,10 @@ static void __init set_quirks(void)
 		interface->capability |= ACER_CAP_BRIGHTNESS;
 
 	if (quirks->turbo)
-		interface->capability |= ACER_CAP_TURBO_OC;
+		interface->capability |= ACER_CAP_TURBO_OC | ACER_CAP_TURBO_LED;
 
 	if (quirks->cpu_fans | quirks->gpu_fans)
-		interface->capability |= ACER_CAP_TURBO_LED | ACER_CAP_TURBO_FAN;
+		interface->capability |= ACER_CAP_TURBO_FAN;
 }
 
 static int __init dmi_matched(const struct dmi_system_id *dmi)


### PR DESCRIPTION
Creates a fan control device for any of the listed laptops with a fan quirk.  This device can accept ascii or binary input (e.g. can be written to with echo, or via a program like python writing 0x00 and 0x01.)

`echo 1 > /dev/acer-max-fan-0` to turn on, `echo 0 > /dev/acer-max-fan-0` to turn off again.

I split the capabilities so that we can distinguish between laptops that have a turbo button, and laptops that don't but still have the fans controlled via the EC.  I put my own laptop (the PH517-61) in this category, and also the PH517-51 (as it's the same laptop but with Intel/Nvidia.)