### PR TITLE
Add secure boot support for Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,19 @@ obj-m	:= src/facer.o
 KERNELDIR ?= /lib/modules/$(shell uname -r)/build
 PWD       := $(shell pwd)
 
+# Sign the kernel module for secure boot (Ubuntu)
+# https://wiki.ubuntu.com/UEFI/SecureBoot/Signing
+KEY := /var/lib/shim-signed/mok/MOK.priv
+X509 := /var/lib/shim-signed/mok/MOK.der
+
 all: default
 
 default:
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
+
+	if [ -f "$(KEY)" ] && [ -f "$(X509)" ]; then \
+		sudo kmodsign sha512 $(KEY) $(X509) src/facer.ko; \
+	fi
 
 install:
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules_install

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Check the output of this command:
 If the directory exists, it may work fine. Otherwise, RGB will not work at all.
 
 ## Requirements
-Secure boot must be disabled.  
+If you have secure boot enabled, you are not using Ubuntu and installation failed with error `Key was rejected by service`, you can sign the module yourself by following the instructions [here](https://github.com/JafarAkhondali/acer-predator-turbo-and-rgb-keyboard-linux-module/issues/28#issuecomment-1054423776).
+
 Install linux headers using your distro package manager:
 Ubuntu (or other Debian baseds distros):  
 `sudo apt-get install linux-headers-$(uname -r) gcc make`


### PR DESCRIPTION
Partly resolve #28 

Sign the kernel module in the makefile for secure boot in Ubuntu: https://wiki.ubuntu.com/UEFI/SecureBoot/Signing