### PR TITLE
Patch for kernel 6.4

### DIFF
--- a/src/facer.c
+++ b/src/facer.c
@@ -2027,7 +2027,13 @@ static int __init gaming_kbbl_cdev_init(void)
 
 	dev_major = MAJOR(dev);
 
-	gkbbl_dev_class = class_create(THIS_MODULE, GAMING_KBBL_CHR);
+
+	#if RTLNX_VER_MIN(6, 4, 0)
+		gkbbl_dev_class = class_create(GAMING_KBBL_CHR);
+	#else
+		gkbbl_dev_class = class_create(THIS_MODULE, GAMING_KBBL_CHR);
+	#endif
+
 	gkbbl_dev_class->dev_uevent = gkbbl_dev_uevent;
 
 	cdev_init(&gkbbl_dev_data.cdev, &gkbbl_dev_fops);
@@ -2135,7 +2141,12 @@ static int __init gaming_kbbl_static_cdev_init(void)
 
 	dev_major = MAJOR(dev);
 
-	gkbbl_static_dev_class = class_create(THIS_MODULE, GAMING_KBBL_STATIC_CHR);
+	#if RTLNX_VER_MIN(6, 4, 0)
+		gkbbl_static_dev_class = class_create(GAMING_KBBL_STATIC_CHR);
+	#else
+		gkbbl_static_dev_class = class_create(THIS_MODULE, GAMING_KBBL_STATIC_CHR);
+	#endif
+
 	gkbbl_static_dev_class->dev_uevent = gkbbl_static_dev_uevent;
 
 	cdev_init(&gkbbl_static_dev_data.cdev, &gkbbl_static_dev_fops);


### PR DESCRIPTION
Added support for Linux Kernel 6.4
changes should be compatible to older kernel version
### before patch
![image](https://github.com/JafarAkhondali/acer-predator-turbo-and-rgb-keyboard-linux-module/assets/71018479/6c588c58-970d-4c8c-afb3-d2433ad5de47)
### after patch
![image](https://github.com/JafarAkhondali/acer-predator-turbo-and-rgb-keyboard-linux-module/assets/71018479/f64b3a5a-278a-4818-9634-44f27a873dbb)
