### PR TITLE
add PT316-51 support

### DIFF
--- a/src/facer.c
+++ b/src/facer.c
@@ -521,6 +521,11 @@ static struct quirk_entry quirk_acer_predator_pt315_52 = {
 		.cpu_fans = 1,
 		.gpu_fans = 1,
 };
+static struct quirk_entry quirk_acer_predator_pt316_51 = {
+		.turbo = 1,
+		.cpu_fans = 1,
+		.gpu_fans = 1,
+};
 static struct quirk_entry quirk_acer_predator_pt515_51 = {
 		.turbo = 1,
 		.cpu_fans = 1,
@@ -907,6 +912,15 @@ static const struct dmi_system_id acer_quirks[] __initconst = {
 						DMI_MATCH(DMI_PRODUCT_NAME, "Predator PT515-51"),
 				},
 				.driver_data = &quirk_acer_predator_pt515_51,
+		},
+		{
+				.callback = dmi_matched,
+				.ident = "Acer Predator PT316-51",
+				.matches = {
+						DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+						DMI_MATCH(DMI_PRODUCT_NAME, "Predator PT316-51"),
+				},
+				.driver_data = &quirk_acer_predator_pt316_51,
 		},
 		{
 				.callback = dmi_matched,


### PR DESCRIPTION
I added struct for my device model, 'Acer Predator Triton 300 SE pt316-51s' and now the turbo button works (except Turbo button led). 

#141 

