### PR TITLE
Added turbo flag /sys/devices/platform/fan/fan_turbo_state

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,12 @@ sudo ./install_openrc.sh
 ```
 
 ## Usage
-Turbo mode should work fine by using the turbo button on keyboard.
+Turbo mode should work fine by using the turbo button on keyboard. A enabled/disabled read-only flag is stored at /sys/devices/platform/fan/fan_turbo_state.
+
+```bash
+cat /sys/devices/platform/fan/fan_turbo_state
+disabled
+```
 
 For RGB, the module will mount a new character device at `/dev/acer-gkbbl-0` to communicate
 with kernel space. 


### PR DESCRIPTION
Added a kernel object which **updates /sys/devices/platform/fan/fan_turbo_state with the global turbo_state variable** when the file is read. Writes literal 'enabled' or 'disabled'. Added example to readme:

```bash
cat /sys/devices/platform/fan/fan_turbo_state
disabled
```

Excuse my poor __init and __exit functions at the end of facer.c. I got 0 experience in kernel stuff, and this is my first pull request.

Tested on my Predator Trition 300 PT315-52-75B7 running Mint Cinnamon

System:
  Host: Predator Kernel: 5.15.0-91-generic x86_64 bits: 64 compiler: gcc
    v: 11.4.0 Desktop: Cinnamon 6.0.4 tk: GTK 3.24.33 info: docker wm: muffin
    vt: 7 dm: LightDM 1.30.0 Distro: Linux Mint 21.3 Virginia
    base: Ubuntu 22.04 jammy

I use the flag to set higher clock rates during max fan operation. Gets me extra MHz before throttling.