### PR TITLE
Fixed possible privilege escalation vulnerability

### DIFF
--- a/install_service.sh
+++ b/install_service.sh
@@ -61,6 +61,7 @@ ExecStart=/bin/bash ./install.sh
 [Install]
 WantedBy=multi-user.target
 EOF
+	chown -R root:root $target_dir
 
 	systemctl daemon-reload
 	systemctl start $service


### PR DESCRIPTION
The service runs /opt/turbo-fan/install.sh as root which itself in turn runs the makefile. If these files are editable by the user account this is a potential avenue for privilege escalation, as any modifications made to install.sh or the makefile by a malicious agent will be run as root the next time the computer starts. while the chance of this happening is low, I'd prefer if it was none.