### PR TITLE
Fixes path errors in install_service.sh

### DIFF
--- a/install_service.sh
+++ b/install_service.sh
@@ -72,17 +72,17 @@ cd $target_dir
 
 rm /dev/acer-gkbbl-0 /dev/acer-gkbbl-static-0 -f
 
-if [ "\$(uname -r)" != "\$KERNELVERSION" ] || [ ! -f $targetdir/src/facer.ko ]; then
+if [ "\$(uname -r)" != "\$KERNELVERSION" ] || [ ! -f $target_dir/src/facer.ko ]; then
 	make clean
-    source install.sh
-	sed -i "s/^KERNELVERSION.*/KERNELVERSION=\"\$(uname -r)\"/" service.sh
+    source ./install.sh
+	sed -i "s/^KERNELVERSION.*/KERNELVERSION=\"\$(uname -r)\"/" $target_dir/service.sh
 else
 	rmmod acer_wmi
 	rmmod facer
 	modprobe wmi
 	modprobe sparse-keymap
 	modprobe video
-	insmod src/facer.ko
+	insmod $target_dir/src/facer.ko
 fi
 EOF
 


### PR DESCRIPTION
While reinstalling the module on my system I noticed that service.sh, which is run by turbo-fan.service, didn't work correctly. 

1) The check against  "-f $targetdir/src/facer.ko" was missing the underscore in $target_dir which resulted in an incorrect path and prompted a rebuild every time.

2) source install.sh failed on my system because of the missing ./

For completeness sake I added the absolute path via the $target_dir variable wherever sensible. 