### PR TITLE
fixed turbo key not working on PHN16-71

### DIFF
--- a/src/facer.c
+++ b/src/facer.c
@@ -2125,7 +2125,7 @@ static void WMID_gaming_set_fan_mode(u8 fan_mode)
 		gpu_fan_config1 |= fan_mode << (2 * i + 6);
 	WMID_gaming_set_u64(gpu_fan_config2 | gpu_fan_config1 << 16, ACER_CAP_TURBO_FAN);
 }
- 
+
 static int WMID_gaming_set_misc_setting(enum acer_wmi_gaming_misc_setting setting, u8 value)
 {
 	acpi_status status;
@@ -2851,7 +2851,7 @@ static int acer_platform_profile_setup(struct platform_device *device)
 			&device->dev, "acer-wmi", NULL, &acer_predator_v4_platform_profile_ops);
 		if (IS_ERR(platform_profile_device))
 			return PTR_ERR(platform_profile_device);
-	
+
 		platform_profile_support = true;
 
 		/* Set default non-turbo profile  */
@@ -2975,7 +2975,7 @@ static int acer_thermal_profile_change(void)
 		/* Store non-turbo profile for turbo mode toggle*/
 		if (tp != ACER_PREDATOR_V4_THERMAL_PROFILE_TURBO_WMI)
 			last_non_turbo_profile = tp;
-		
+
 		#if RTLNX_VER_MIN(6, 14, 0)
 		platform_profile_notify(platform_profile_device);
 		#else
@@ -3314,7 +3314,7 @@ static void acer_wmi_notify(
 				pr_warn("macro key %d pressed (only 1 to 5 are known)\n", return_value.device_state);
 			break;
 		}
-		else if (return_value.key_num == 0x4)
+		else if (return_value.key_num == 0x4 || return_value.key_num == 0x5)
 			acer_toggle_turbo();
 		else if (return_value.key_num == 0x5 && has_cap(ACER_CAP_PLATFORM_PROFILE))
 			acer_thermal_profile_change();


### PR DESCRIPTION
### Summary : 
This PR fixes an issue on **PHN16-71** (_maybe other models too_) where the **Turbo key no longer triggers max fan speed**. This is due to unhandled WMI key event. This change likely stems from recent firmware or kernel updates and the fix expands the handler to support both key codes for broader compatibility.

### Type of Change:
- [x] 🐛 BUG FIX

###  Related Issue
Closes #249 

### Step-by-Step Fix : 
1. To check kernel log, add this line after **acer_wmi_notify()** function, right after extracting return_value in facer.c : 
```
pr_info("Acer WMI event: function=0x%x key_num=0x%x device_state=0x%x\n",
   return_value.function, return_value.key_num, return_value.device_state);
```
![Screenshot from 2025-06-24 19-05-39](https://github.com/user-attachments/assets/02d90f37-a50f-4e3d-be4c-65163dc60a5b)

2. `sudo ./refresh.sh` : to reload module

3. `sudo dmesg -w` to print kernel logs and then press turbo key
Output : `[10614.952927] facer: Acer WMI event: function=0x7 key_num=0x5 device_state=0x1`
![Screenshot from 2025-06-24 19-12-27](https://github.com/user-attachments/assets/13283b31-b018-4630-98d3-49c276c4d219)

4. The above log shows key_num=0x5 whereas in code, **only key_num == 0x4 triggers acer_toggle_turbo()** which explains why turbo fans were not working

5. This fix expands the handler to support both key codes for broader compatibility.
![Screenshot from 2025-06-24 19-16-56](https://github.com/user-attachments/assets/ce7aec1c-44ce-40ae-8862-1153a2b20b1c)

6.  Refresh module and then press turbo key. Now it works and the fan rotates at max speed.

### Additional Context : 
1. This issue appears hardware- or firmware-specific but is likely affecting all PHN16-71 users and possibly newer Predator models with similar key mappings. 
2. Without this patch, the Turbo button on affected Acer laptops is non-functional in Linux, reducing usability for users who depend on quick thermal/performance switching (e.g., heavy workloads).
3. This fix is not a breaking change. It retains the existing behavior (key_num == 0x4) and adds support for an additional key code (key_num == 0x5), ensuring backward compatibility.

### System Details :
_Laptop Model: Acer Predator PHN16-71
BIOS Version: V1.18
Kernel Version: 6.8.0-60-generic_
